### PR TITLE
preserve shipping method when shipments change

### DIFF
--- a/api/spec/controllers/spree/api/orders_controller_spec.rb
+++ b/api/spec/controllers/spree/api/orders_controller_spec.rb
@@ -499,20 +499,6 @@ module Spree
         expect(json_response["user_id"]).to eq(original_id)
       end
 
-      context "order has shipments" do
-        before { order.create_proposed_shipments }
-
-        it "clears out all existing shipments on line item udpate" do
-          previous_shipments = order.shipments
-          api_put :update, :id => order.to_param, :order => {
-            :line_items => {
-              0 => { :id => line_item.id, :quantity => 10 }
-            }
-          }
-          expect(order.reload.shipments).to be_empty
-        end
-      end
-
       context "with a line item" do
         let(:order) { create(:order_with_line_items) }
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -508,17 +508,22 @@ module Spree
       persist_totals
     end
 
-    # Clean shipments and make order back to address state
-    #
-    # At some point the might need to force the order to transition from address
-    # to delivery again so that proper updated shipments are created.
-    # e.g. customer goes back from payment step and changes order items
-    def ensure_updated_shipments
+    # This method used to be known as ensure_updated_shipments but it stopped
+    # messing with shipments in order to preserve a user's selected shipping method.
+    # That exposed some oddness, which the new name represents.
+    # As of this writing, this method is only called from OrderContents, but is
+    # called every time the order is modified. Which means that we're almost
+    # always restarting the checkout flow at the 'cart' state for every modification
+    # to a pre-completed order.
+    # TODO understand this at a coarser grain and improve it
+    def probably_restart_checkout_flow
       if !completed? && shipments.all?(&:pending?)
+        # NOTE: if there are no shipments, [].all?(&:pending?) is true
+        # which is probably not what we want
         restart_checkout_flow
       end
-
     end
+    alias :ensure_updated_shipments :probably_restart_checkout_flow
 
     def restart_checkout_flow
       return if self.state == 'cart'

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -497,8 +497,7 @@ module Spree
         raise CannotRebuildShipments.new(Spree.t(:cannot_rebuild_shipments_shipments_not_pending))
       else
         adjustments.shipping.destroy_all
-        shipments.destroy_all
-        self.shipments = Spree::Stock::Coordinator.new(self).shipments
+        self.shipments.replace(Spree::Stock::Coordinator.new(self).shipments)
       end
     end
 
@@ -516,8 +515,6 @@ module Spree
     # e.g. customer goes back from payment step and changes order items
     def ensure_updated_shipments
       if !completed? && shipments.all?(&:pending?)
-        self.shipments.destroy_all
-        self.update_column(:shipment_total, 0)
         restart_checkout_flow
       end
 
@@ -530,6 +527,7 @@ module Spree
         state: 'cart',
         updated_at: Time.now,
       )
+      # Note: what if this did contents.advance instead of self.next! ?
       self.next! if self.line_items.size > 0
     end
 

--- a/core/app/models/spree/order_contents.rb
+++ b/core/app/models/spree/order_contents.rb
@@ -30,7 +30,7 @@ module Spree
           # promotion rules would not be triggered.
           reload_totals
           PromotionHandler::Cart.new(order).activate
-          order.ensure_updated_shipments
+          order.probably_restart_checkout_flow
         end
         reload_totals
         true
@@ -60,7 +60,7 @@ module Spree
       def after_add_or_remove(line_item, options = {})
         reload_totals
         shipment = options[:shipment]
-        shipment.present? ? shipment.update_amounts : order.ensure_updated_shipments
+        shipment.present? ? shipment.update_amounts : order.probably_restart_checkout_flow
         PromotionHandler::Cart.new(order, line_item).activate
         ItemAdjustments.new(line_item).update
         reload_totals

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -27,6 +27,7 @@ FactoryGirl.define do
         line_items_attributes { [{}] * line_items_count }
         shipment_cost 100
         shipping_method nil
+        select_shipping_rate false
       end
 
       after(:create) do |order, evaluator|
@@ -36,7 +37,9 @@ FactoryGirl.define do
         end
         order.line_items.reload
 
-        create(:shipment, order: order, cost: evaluator.shipment_cost, shipping_method: evaluator.shipping_method, address: evaluator.ship_address)
+        create(:shipment, order: order, cost: evaluator.shipment_cost,
+               shipping_method: evaluator.shipping_method, address: evaluator.ship_address,
+               select_shipping_rate: evaluator.select_shipping_rate)
         order.shipments.reload
 
         order.update!

--- a/core/lib/spree/testing_support/factories/shipment_factory.rb
+++ b/core/lib/spree/testing_support/factories/shipment_factory.rb
@@ -8,11 +8,12 @@ FactoryGirl.define do
 
     transient do
       shipping_method nil
+      select_shipping_rate false
     end
 
-    after(:create) do |shipment, evalulator|
-      shipping_method = evalulator.shipping_method || create(:shipping_method, cost: evalulator.cost)
-      shipment.add_shipping_method(shipping_method, true)
+    after(:create) do |shipment, evaluator|
+      shipping_method = evaluator.shipping_method || create(:shipping_method, cost: evaluator.cost)
+      shipment.add_shipping_method(shipping_method, evaluator.select_shipping_rate)
 
       shipment.order.line_items.each do |line_item|
         line_item.quantity.times do

--- a/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
+++ b/core/spec/lib/spree/core/unreturned_item_charger_spec.rb
@@ -9,6 +9,7 @@ describe Spree::UnreturnedItemCharger do
   let(:exchange_shipment) do
     create(:shipment,
            order: shipped_order,
+           select_shipping_rate: true,
            state: 'shipped',
            stock_location: original_stock_location,
            created_at: 5.days.ago)

--- a/core/spec/models/spree/order/checkout_spec.rb
+++ b/core/spec/models/spree/order/checkout_spec.rb
@@ -325,7 +325,7 @@ describe Spree::Order, :type => :model do
 
       context "correctly determining payment required based on shipping information" do
         let(:shipment) do
-          FactoryGirl.create(:shipment)
+          FactoryGirl.create(:shipment, select_shipping_rate: true)
         end
 
         before do

--- a/core/spec/models/spree/order_contents_spec.rb
+++ b/core/spec/models/spree/order_contents_spec.rb
@@ -18,9 +18,9 @@ describe Spree::OrderContents, :type => :model do
     end
 
     context 'given a shipment' do
-      it "ensure shipment calls update_amounts instead of order calling ensure_updated_shipments" do
+      it "ensure shipment calls update_amounts instead of order calling probably_restart_checkout_flow" do
         shipment = create(:shipment)
-        expect(subject.order).to_not receive(:ensure_updated_shipments)
+        expect(subject.order).to_not receive(:probably_restart_checkout_flow)
         expect(shipment).to receive(:update_amounts)
         subject.add(variant, 1, shipment: shipment)
       end
@@ -28,7 +28,7 @@ describe Spree::OrderContents, :type => :model do
 
     context 'not given a shipment' do
       it "ensures updated shipments" do
-        expect(subject.order).to receive(:ensure_updated_shipments)
+        expect(subject.order).to receive(:probably_restart_checkout_flow)
         subject.add(variant)
       end
     end
@@ -116,10 +116,10 @@ describe Spree::OrderContents, :type => :model do
     end
 
     context 'given a shipment' do
-      it "ensure shipment calls update_amounts instead of order calling ensure_updated_shipments" do
+      it "ensure shipment calls update_amounts instead of order calling probably_restart_checkout_flow" do
         line_item = subject.add(variant, 1)
         shipment = create(:shipment)
-        expect(subject.order).to_not receive(:ensure_updated_shipments)
+        expect(subject.order).to_not receive(:probably_restart_checkout_flow)
         expect(shipment).to receive(:update_amounts)
         subject.remove(variant, 1, shipment: shipment)
       end
@@ -128,7 +128,7 @@ describe Spree::OrderContents, :type => :model do
     context 'not given a shipment' do
       it "ensures updated shipments" do
         line_item = subject.add(variant, 1)
-        expect(subject.order).to receive(:ensure_updated_shipments)
+        expect(subject.order).to receive(:probably_restart_checkout_flow)
         subject.remove(variant)
       end
     end
@@ -164,10 +164,10 @@ describe Spree::OrderContents, :type => :model do
 
   context "#remove_line_item" do
     context 'given a shipment' do
-      it "ensure shipment calls update_amounts instead of order calling ensure_updated_shipments" do
+      it "ensure shipment calls update_amounts instead of order calling probably_restart_checkout_flow" do
         line_item = subject.add(variant, 1)
         shipment = create(:shipment)
-        expect(subject.order).to_not receive(:ensure_updated_shipments)
+        expect(subject.order).to_not receive(:probably_restart_checkout_flow)
         expect(shipment).to receive(:update_amounts)
         subject.remove_line_item(line_item, shipment: shipment)
       end
@@ -176,7 +176,7 @@ describe Spree::OrderContents, :type => :model do
     context 'not given a shipment' do
       it "ensures updated shipments" do
         line_item = subject.add(variant, 1)
-        expect(subject.order).to receive(:ensure_updated_shipments)
+        expect(subject.order).to receive(:probably_restart_checkout_flow)
         subject.remove_line_item(line_item)
       end
     end
@@ -239,7 +239,7 @@ describe Spree::OrderContents, :type => :model do
     end
 
     it "ensures updated shipments" do
-      expect(subject.order).to receive(:ensure_updated_shipments)
+      expect(subject.order).to receive(:probably_restart_checkout_flow)
       subject.update_cart params
     end
   end

--- a/core/spec/models/spree/order_shipping_method_spec.rb
+++ b/core/spec/models/spree/order_shipping_method_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Spree::Order do
+  let(:order) { create(:order_with_line_items) }
+  let(:quadcopter) { create(:shipping_method, name: "Quads'r'us", code: "QUADSRUS", cost: 200) }
+
+  it "preserves selected shipping method when update_cart and next! called" do
+    #choose more expensive quadcopter shipping method
+    original_shipment = order.shipments.first
+    quadcopter_rate = original_shipment.add_shipping_method(quadcopter)
+    original_shipment.selected_shipping_rate_id = quadcopter_rate.id
+    expect(order.shipments.first.shipping_method).to eq quadcopter
+
+    order.contents.update_cart({}) #contents don't really matter
+    order.contents.advance
+
+    expect(order.shipments.first.shipping_method).to eq quadcopter
+  end
+
+  let(:cheap_ups_cost) { 10 }
+
+  it "reaching delivery step with no explicit selection selects cheapest shipping rate" do
+    # ... even if the shipping method is created after the order
+    order.contents.add(create(:variant), 1)
+    cheap_ups = create(:shipping_method, name: "Cheap UPS Ground", cost: cheap_ups_cost)
+
+    order.contents.advance
+    final_selected_shipping_rate = order.shipments.first.selected_shipping_rate
+
+    expect(final_selected_shipping_rate.shipping_method).to eq cheap_ups
+    expect(final_selected_shipping_rate.cost).to eq cheap_ups_cost
+  end
+end

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -268,20 +268,9 @@ describe Spree::Order, :type => :model do
           order.shipments.create!
         end
 
-        it "destroys current shipments" do
-          order.ensure_updated_shipments
-          expect(order.shipments).to be_empty
-        end
-
         it "puts order back in address state" do
           order.ensure_updated_shipments
           expect(order.state).to eql "cart"
-        end
-
-        it "resets shipment_total" do
-          order.update_column(:shipment_total, 5)
-          order.ensure_updated_shipments
-          expect(order.shipment_total).to eq(0)
         end
 
         it "does nothing if any shipments are ready" do
@@ -303,17 +292,6 @@ describe Spree::Order, :type => :model do
       before do
         order.state = 'address'
         order.shipments.create!
-      end
-
-      it "destroys current shipments" do
-        order.ensure_updated_shipments
-        expect(order.shipments).to be_empty
-      end
-
-      it "resets shipment_total" do
-        order.update_column(:shipment_total, 5)
-        order.ensure_updated_shipments
-        expect(order.shipment_total).to eq(0)
       end
 
       it "puts the order in the cart state" do

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -269,19 +269,19 @@ describe Spree::Order, :type => :model do
         end
 
         it "puts order back in address state" do
-          order.ensure_updated_shipments
+          order.probably_restart_checkout_flow
           expect(order.state).to eql "cart"
         end
 
         it "does nothing if any shipments are ready" do
           shipment = create(:shipment, order: subject, state: "ready")
-          expect { subject.ensure_updated_shipments }.not_to change { subject.reload.shipments }
+          expect { subject.probably_restart_checkout_flow }.not_to change { subject.reload.shipments }
           expect { shipment.reload }.not_to raise_error
         end
 
         it "does nothing if any shipments are shipped" do
           shipment = create(:shipment, order: subject, state: "shipped")
-          expect { subject.ensure_updated_shipments }.not_to change { subject.reload.shipments }
+          expect { subject.probably_restart_checkout_flow }.not_to change { subject.reload.shipments }
           expect { shipment.reload }.not_to raise_error
         end
       end
@@ -295,7 +295,7 @@ describe Spree::Order, :type => :model do
       end
 
       it "puts the order in the cart state" do
-        order.ensure_updated_shipments
+        order.probably_restart_checkout_flow
         expect(order.state).to eq "cart"
       end
     end
@@ -308,21 +308,9 @@ describe Spree::Order, :type => :model do
         order.shipments.create!
       end
 
-      it "does not destroy the current shipments" do
-        expect {
-          order.ensure_updated_shipments
-        }.not_to change { order.shipments }
-      end
-
-      it "does not reset the shipment total" do
-        expect {
-          order.ensure_updated_shipments
-        }.not_to change { order.shipment_total }
-      end
-
       it "does not put the order back in the address state" do
         expect {
-          order.ensure_updated_shipments
+          order.probably_restart_checkout_flow
         }.not_to change { order.state }
       end
     end
@@ -334,15 +322,7 @@ describe Spree::Order, :type => :model do
         order.shipments.create!
 
         expect {
-          order.ensure_updated_shipments
-        }.not_to change { order.shipment_total }
-
-        expect {
-          order.ensure_updated_shipments
-        }.not_to change { order.shipments }
-
-        expect {
-          order.ensure_updated_shipments
+          order.probably_restart_checkout_flow
         }.not_to change { order.state }
       end
     end

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -184,11 +184,11 @@ describe Spree::Shipment, :type => :model do
       before { allow(shipment).to receive(:can_get_rates?){ true } }
 
       it 'should request new rates, and maintain shipping_method selection' do
-        expect(Spree::Stock::Estimator).to receive(:new).with(shipment.order).and_return(mock_estimator)
-        allow(shipment).to receive_messages(shipping_method: shipping_method2)
+        # select more expensive shipping_method2
+        shipping_method2_rate = shipment.add_shipping_method(shipping_method2)
+        shipment.selected_shipping_rate_id = shipping_method2_rate.id
 
-        expect(shipment.refresh_rates).to eq(shipping_rates)
-        expect(shipment.reload.selected_shipping_rate.shipping_method_id).to eq(shipping_method2.id)
+        expect(shipment.selected_shipping_rate.shipping_method_id).to eq(shipping_method2.id)
       end
 
       it 'should handle no shipping_method selection' do


### PR DESCRIPTION
https://bonobos.atlassian.net/browse/ENG-3511

The main impetus of this is Tulip in which the guides have a much more
non-linear approach to creating an order, but the same problem exists
through the web client too.

Other approaches have been tried, but lets try this within the
Estimator itself. An extra side-effect of this is that we don't
delete shipments in Order#ensure_updated_shipments so that's poorly
named now, but it also raises a question of why it's called when it
is. This means a shipment will stick with an order if created before we
reach the "delivery" state of the order. Upon transition into "delivery"
then #created_proposed_shipments gets called to ensure they're correct.
The new logic in the Estimator now will re-select any prior shipping
method/rate selection the customer had previously made.
