### PR TITLE
Stop unscoping default_prices

### DIFF
--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -18,10 +18,6 @@ module Spree
 
       after_save :save_default_price
 
-      def default_price
-        Spree::Price.unscoped { super }
-      end
-
       def has_default_price?
         !self.default_price.nil?
       end

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -63,6 +63,10 @@ module Spree
       delegate :"#{attr}", :"#{attr}=", to: :find_or_build_master
     end
 
+    def price
+      master.price || Spree::Price.unscoped { master.price }
+    end
+
     delegate :display_amount, :display_price, :has_default_price?, to: :find_or_build_master
 
     delegate :images, to: :master, prefix: true

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -78,6 +78,31 @@ describe Spree::Product, :type => :model do
       end
     end
 
+    describe "#price" do
+      let(:master) { product.master }
+
+      context "product does not have deleted_at" do
+        it "gets the scoped default price" do
+          expect(product.price).to eq product.master.price
+        end
+      end
+
+      context "product does have deleted_at" do
+        let(:master_price) { Spree::Price.unscoped { master.price } }
+
+        before do
+          product.destroy
+          product.reload
+        end
+
+         it "gets the unscoped default price" do
+           expect(product.price).to_not be_nil
+           expect(product.price).to eq master_price
+        end
+      end
+    end
+
+
     context "product has no variants" do
       context "#destroy" do
         it "should set deleted_at value" do

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -183,6 +183,16 @@ describe Spree::Variant, :type => :model do
       end
     end
 
+    context "when a default price has been deleted" do
+      it "does not display that price as default" do
+        expect(variant.default_price.amount).to eq(19.99)
+        variant.prices.first.delete
+        variant.prices << create(:price, :variant => variant, :currency => "USD", :amount => 12.12)
+        variant.reload
+        expect(variant.default_price.amount).to eq(12.12)
+      end
+    end
+
     context "when adding multiple prices" do
       it "it can reassign a default price" do
         expect(variant.default_price.amount).to eq(19.99)


### PR DESCRIPTION
`Spree::Price#default_price` should not be unscoped; this is causing some variants to have incorrect/inconsistent prices in the admin and front-end, as it is returning the first price with `is_default: true`, even if it is a deleted price. 
