### PR TITLE
ensure exchanges use cheapest shipping option

### DIFF
--- a/core/app/models/spree/exchange.rb
+++ b/core/app/models/spree/exchange.rb
@@ -25,8 +25,11 @@ module Spree
       @order.shipments += shipments
       @order.save!
       shipments.each do |shipment|
+        cheapest_rate = shipment.shipping_rates.min_by(&:cost)
+        shipment.selected_shipping_rate_id = cheapest_rate.id
         shipment.update!(@order)
         shipment.finalize!
+        shipment.reload
       end
     end
 

--- a/core/spec/models/spree/exchange_spec.rb
+++ b/core/spec/models/spree/exchange_spec.rb
@@ -50,6 +50,11 @@ module Spree
         expect(new_inventory_units.first.line_item).to eq return_item.inventory_unit.line_item
       end
 
+      it "sends exchange shipment with free shipping method" do
+        create(:free_shipping_method)
+        expect(subject.last.selected_shipping_rate.cost).to eq 0
+      end
+
       context "when it cannot create shipments for all items" do
         before do
           StockItem.where(:variant_id => return_item.exchange_variant_id).destroy_all


### PR DESCRIPTION
ENG-3603
Previous work to preserve a selected shipping rate has caused
exchanges to potentially be shipped with upgraded shipping if the
original order was. This makes exchanges explicitly choose the
cheapest shipping method.
