### PR TITLE
Add ability to define roles where auto-api-key create is desired.

### DIFF
--- a/api/spec/models/spree/legacy_user_spec.rb
+++ b/api/spec/models/spree/legacy_user_spec.rb
@@ -26,29 +26,75 @@ module Spree
       expect { user.clear_spree_api_key }.to change(user, :spree_api_key).to be_blank
     end
 
-    context "admin role auto-api-key grant" do # so the admin user can do admin api actions
-      let(:user) { create(:user) }
-      before { expect(user.spree_roles).to be_blank }
-      subject { user.spree_roles << role }
+    context "auto-api-key grant" do
+      context "after role user create" do
+        let(:user) { create(:user) }
+        before { expect(user.spree_roles).to be_blank }
+        subject { user.spree_roles << role }
 
-      context "admin role" do
-        let(:role) { create(:role, name: "admin") }
+        context "roles_for_auto_api_key default" do
+          let(:role) { create(:role, name: "admin") }
 
-        context "the user has no api key" do
-          before { user.clear_spree_api_key! }
-          it { expect { subject }.to change { user.reload.spree_api_key }.from(nil) }
+          context "the user has no api key" do
+            before { user.clear_spree_api_key! }
+            it { expect { subject }.to change { user.reload.spree_api_key }.from(nil) }
+          end
+
+          context "the user already has an api key" do
+            before { user.generate_spree_api_key! }
+            it { expect { subject }.not_to change { user.reload.spree_api_key } }
+          end
         end
 
-        context "the user already has an api key" do
-          before { user.generate_spree_api_key! }
-          it { expect { subject }.not_to change { user.reload.spree_api_key } }
+        context "roles_for_auto_api_key is defined" do
+          let (:role) { create(:role, name: 'hobbit') }
+          let(:undesired_role) { create(:role, name: "foo") }
+
+          before {
+            user.clear_spree_api_key!
+            Spree::Config.roles_for_auto_api_key = ['hobbit']
+          }
+
+          it { expect { subject }.to change { user.reload.spree_api_key }.from(nil) }
+          it { expect { user.spree_roles << undesired_role }.not_to change { user.reload.spree_api_key } }
+        end
+
+        context "for all roles" do
+          let (:role) { create(:role, name: 'hobbit') }
+          let (:other_role) { create(:role, name: 'wizard') }
+          let (:other_user) { create(:user) }
+
+          before {
+            user.clear_spree_api_key!
+            other_user.clear_spree_api_key!
+            Spree::Config.generate_api_key_for_all_roles = true
+          }
+
+          it { expect { subject }.to change { user.reload.spree_api_key }.from(nil) }
+          it { expect { other_user.spree_roles << other_role }.to change { other_user.reload.spree_api_key }.from(nil) }
         end
       end
 
-      context "non-admin role" do
-        let(:role) { create(:role, name: "foo") }
-        before { user.clear_spree_api_key! }
-        it { expect { subject }.not_to change { user.reload.spree_api_key } }
+      context "after user create" do
+        let(:user) { LegacyUser.new }
+
+        context "generate_api_key_for_all_roles" do
+          it "does not grant api key default" do
+            expect(user.spree_api_key).to eq(nil)
+
+            user.save!
+            expect(user.spree_api_key).to eq(nil)
+          end
+
+          it "grants an api key on create when set to true" do
+            Spree::Config.generate_api_key_for_all_roles = true
+
+            expect(user.spree_api_key).to eq(nil)
+
+            user.save!
+            expect(user.spree_api_key).not_to eq(nil)
+          end
+        end
       end
     end
   end

--- a/core/app/models/spree/app_configuration.rb
+++ b/core/app/models/spree/app_configuration.rb
@@ -136,6 +136,11 @@ module Spree
     #     charged (default: +14+)
     preference :expedited_exchanges_days_window, :integer, default: 14
 
+    # @!attribute [rw] generate_api_key_for_all_roles
+    #   @return [Boolean] Allow generating api key automatically for user
+    #   at role_user creation for all roles. (default: +false+)
+    preference :generate_api_key_for_all_roles, :boolean, default: false
+
     # @!attribute [rw] layout
     #   @return [String] template to use for layout on the frontend (default: +"spree/layouts/spree_application"+)
     preference :layout, :string, default: 'spree/layouts/spree_application'
@@ -192,6 +197,12 @@ module Spree
     # @!attribute [rw] return_eligibility_number_of_days
     #   @return [Integer] default: 365
     preference :return_eligibility_number_of_days, :integer, default: 365
+
+    # @!attribute [rw] roles_for_auto_api_key
+    #   @return [Array] An array of roles where generating an api key for a user
+    #   at role_user creation is desired when user has one of these roles.
+    #   (default: +['admin']+)
+    preference :roles_for_auto_api_key, :array, default: ['admin']
 
     # @!attribute [rw] shipping_instructions
     #   @return [Boolean] Request instructions/info for shipping (default: +false+)

--- a/core/app/models/spree/role_user.rb
+++ b/core/app/models/spree/role_user.rb
@@ -4,14 +4,12 @@ module Spree
     belongs_to :role, class_name: "Spree::Role"
     belongs_to :user, class_name: Spree::UserClassHandle.new
 
-    after_save :generate_admin_api_key
+    after_create :auto_generate_spree_api_key
 
     private
 
-    def generate_admin_api_key
-      if role.admin? && user.respond_to?(:spree_api_key) && !user.spree_api_key
-        user.generate_spree_api_key!
-      end
+    def auto_generate_spree_api_key
+      user.try!(:auto_generate_spree_api_key)
     end
   end
 end


### PR DESCRIPTION
- Right now we only generate an api key for a new RoleUser's user when a user
  has the admin role. It is desired to be able to define other roles so
  that we can generate an api key for a new RoleUser's user if it
  doesn't exist and the role is defined in whitelisted_roles_for_api_key
