### PR TITLE
Remove default_price unscoping

### DIFF
--- a/core/app/models/concerns/spree/default_price.rb
+++ b/core/app/models/concerns/spree/default_price.rb
@@ -18,10 +18,6 @@ module Spree
 
       after_save :save_default_price
 
-      def default_price
-        Spree::Price.unscoped { super }
-      end
-
       def has_default_price?
         !self.default_price.nil?
       end

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -190,6 +190,16 @@ describe Spree::Variant, :type => :model do
         expect(variant.reload.default_price.amount).to eq(12.12)
       end
     end
+
+    context "when a default price has been deleted and a new one is created" do
+       it "does not display that price as default" do
+         expect(variant.default_price.amount).to eq(19.99)
+         variant.prices.first.delete
+         variant.prices << create(:price, :variant => variant, :currency => "USD", :amount => 12.12)
+         variant.reload
+         expect(variant.default_price.amount).to eq(12.12)
+       end
+     end
   end
 
   describe '.price_in' do


### PR DESCRIPTION
Variants should have non-deleted default prices

This removes the ability to see deleted products/variants prices.
