### PR TITLE
Add admin promotion duplication functionality

### DIFF
--- a/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
+++ b/backend/app/assets/stylesheets/spree/backend/sections/_promotions.scss
@@ -4,6 +4,12 @@
   padding-bottom: 0;
 }
 
+#duplicate-promotions-overlay {
+  pointer-events: none;
+  background-color: light-grey;
+  opacity: 0.5;
+}
+
 #rules_container, #actions_container {
   position: relative;
 

--- a/backend/app/controllers/spree/admin/promotions_controller.rb
+++ b/backend/app/controllers/spree/admin/promotions_controller.rb
@@ -24,6 +24,10 @@ module Spree
         end
       end
 
+      def duplicate
+        @promotion = @promotion.duplicate
+      end
+
       private
 
         def load_bulk_code_information

--- a/backend/app/views/spree/admin/promotions/_promotion_action.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_action.html.erb
@@ -1,12 +1,13 @@
 <div class="promotion_action promotion-block <%= promotion_action.type.to_s.demodulize.underscore %>" id="<%= dom_id promotion_action %>">
   <% type_name = promotion_action.class.name.demodulize.underscore %>
   <h6 class="promotion-title"><%= Spree.t("promotion_action_types.#{type_name}.description") %></h6>
-  <% if can?(:destroy, promotion_action) %>
+  <% if can?(:destroy, promotion_action) && promotion_action.persisted? %>
     <%= link_to_with_icon 'trash', '', spree.admin_promotion_promotion_action_path(@promotion, promotion_action), :remote => true, :method => :delete, :class => 'delete' %>
   <% end %>
 
   <% param_prefix = "promotion[promotion_actions_attributes][#{promotion_action.id}]" %>
   <%= hidden_field_tag "#{param_prefix}[id]", promotion_action.id %>
+  <%= hidden_field_tag "#{param_prefix}[type]", promotion_action.type %>
 
   <%= render :partial => "spree/shared/error_messages", :locals => { :target => promotion_action } %>
   <%= render :partial => "spree/admin/promotions/actions/#{type_name}",

--- a/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
+++ b/backend/app/views/spree/admin/promotions/_promotion_rule.html.erb
@@ -1,12 +1,13 @@
 <div class="promotion_rule promotion-block alpha omega eight columns" id="<%= dom_id promotion_rule %>">
   <% type_name = promotion_rule.class.name.demodulize.underscore %>
   <h6 class='promotion-title <%= 'no-text' if type_name == 'user_logged_in' || type_name == 'first_order'%>'><%= Spree.t("promotion_rule_types.#{type_name}.description") %></h6>
-  <% if can?(:destroy, promotion_rule) %>
+  <% if can?(:destroy, promotion_rule) && promotion_rule.persisted? %>
     <%= link_to_with_icon 'trash', '', spree.admin_promotion_promotion_rule_path(@promotion, promotion_rule), :remote => true, :method => :delete, :class => 'delete' %>
   <% end %>
 
   <% param_prefix = "promotion[promotion_rules_attributes][#{promotion_rule.id}]" %>
   <%= hidden_field_tag "#{param_prefix}[id]", promotion_rule.id %>
+  <%= hidden_field_tag "#{param_prefix}[type]", promotion_rule.type %>
   <%= render :partial => "spree/shared/error_messages", :locals => { :target => promotion_rule } %>
   <%= render :partial => "spree/admin/promotions/rules/#{type_name}", :locals => { :promotion_rule => promotion_rule, :param_prefix => param_prefix } %>
 </div>

--- a/backend/app/views/spree/admin/promotions/actions/_create_adjustment.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_create_adjustment.html.erb
@@ -11,7 +11,6 @@
     <% end %>
   </div>
 
-  <% unless promotion_action.new_record? %>
     <div class="settings field omega four columns">
       <% type_name = promotion_action.calculator.type.demodulize.underscore %>
       <% if lookup_context.exists?("fields",
@@ -24,5 +23,4 @@
       <% end %>
       <%= hidden_field_tag "#{param_prefix}[calculator_attributes][id]", promotion_action.calculator.id %>
     </div>
-  <% end %>
 </div>

--- a/backend/app/views/spree/admin/promotions/actions/_create_item_adjustments.html.erb
+++ b/backend/app/views/spree/admin/promotions/actions/_create_item_adjustments.html.erb
@@ -11,7 +11,6 @@
     <% end %>
   </div>
 
-  <% unless promotion_action.new_record? %>
     <div class="settings field omega four columns">
       <% promotion_action.calculator.preferences.keys.map do |key| %>
         <% field_name = "#{param_prefix}[calculator_attributes][preferred_#{key}]" %>
@@ -22,5 +21,4 @@
       <% end %>
       <%= hidden_field_tag "#{param_prefix}[calculator_attributes][id]", promotion_action.calculator.id %>
     </div>
-  <% end %>
 </div>

--- a/backend/app/views/spree/admin/promotions/duplicate.html.erb
+++ b/backend/app/views/spree/admin/promotions/duplicate.html.erb
@@ -1,0 +1,77 @@
+<% content_for :page_title do %>
+  <%= Spree.t(:duplicating_promotion) %>
+<% end %>
+
+<%= render 'spree/admin/shared/promotion_sub_menu' %>
+
+<% content_for :page_actions do %>
+  <li>
+    <%= button_link_to Spree.t(:back_to_promotions_list), admin_promotions_path, :icon => 'arrow-left' %>
+  </li>
+<% end %>
+
+<%= form_for @promotion, :url => admin_promotions_path, :method => :post do |f| %>
+  <fieldset class="no-border-top">
+    <%= render :partial => 'form', :locals => { :f => f } %>
+    <%= render :partial => 'spree/admin/shared/new_resource_links' %>
+  </fieldset>
+
+  <div id="duplicate-promotions-overlay">
+    <div id="promotion-filters" class="row">
+
+      <div id="rules_container" class="alpha eight columns">
+        <fieldset id="rule_fields" class ="alpha eight columns no-border-bottom no-border-top">
+          <fieldset>
+          <legend align="center"><%= Spree.t(:rules) %></legend>
+            <% if @promotion.rules.any? %>
+              <div class="field">
+                <%= label_tag :promotion_rule_type, Spree.t(:add_rule_of_type) %>
+                <%= select_tag('promotion_rule[type]', options_for_promotion_rule_types(@promotion), :class => 'select2 fullwidth') %>
+              </div>
+          </fieldset>
+          <fieldset class="no-border-top">
+            <div id="promotion-pilicy-select" class="align-center row">
+              <% Spree::Promotion::MATCH_POLICIES.each do |policy| %>
+                <div class="alpha four columns">
+                  <label><%= f.radio_button :match_policy, policy %> <%= Spree.t "promotion_form.match_policies.#{policy}" %></label>
+                </div>
+              <% end %>
+            </div>
+
+            <div id="rules" class="filter_list row">
+              <%= render :partial => 'promotion_rule', :collection => @promotion.rules, :locals => { disallow_destroy: true} %>
+            <% else %>
+              <div class="no-objects-found">
+                <%= Spree.t(:no_rules_added) %>
+              </div>
+            <% end %>
+            </div>
+          </fieldset>
+      </div>
+
+      <div id="actions_container" class="omega eight columns">
+        <fieldset id="action_fields" class="eight columns omega no-border-top">
+          <% options = options_for_select(  Rails.application.config.spree.promotions.actions.map(&:name).map {|name| [ Spree.t("promotion_action_types.#{name.demodulize.underscore}.name"), name] } ) %>
+          <fieldset>
+            <legend align="center"><%= Spree.t(:promotion_actions) %></legend>
+            <% if @promotion.actions.any? %>
+              <div class="field">
+                <%= label_tag :action_type, Spree.t(:add_action_of_type)%>
+                <%= select_tag "action_type", options, :class => 'select2 fullwidth' %>
+              </div>
+          </fieldset>
+
+          <fieldset class="no-border-top">
+            <div id="actions" class="filter_list">
+              <%= render :partial => 'promotion_action',  :collection => @promotion.actions %>
+            <% else %>
+              <div class="no-objects-found">
+                <%= Spree.t(:no_actions_added) %>
+              </div>
+            <% end %>
+            </div>
+          </fieldset>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/backend/app/views/spree/admin/promotions/index.html.erb
+++ b/backend/app/views/spree/admin/promotions/index.html.erb
@@ -99,6 +99,7 @@
             <% if can?(:destroy, promotion) %>
               <%= link_to_delete promotion, :no_text => true %>
             <% end %>
+            <%= link_to_with_icon 'copy', 'duplicate', duplicate_admin_promotion_path(promotion), {:no_text => true} %>
           </td>
         </tr>
       <% end %>

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -13,6 +13,9 @@ Spree::Core::Engine.add_routes do
       resources :promotion_rules
       resources :promotion_actions
       resources :promotion_codes, only: [:index]
+      member do
+        get :duplicate
+      end
     end
 
     resources :promotion_categories, except: [:show]


### PR DESCRIPTION
Adds ‘duplicate’ button to promotion page in admin. Uses a get route to build the promotion on the page, and a POST request to create to create the promotion. Promotion rules and actions are not able to be edited in the duplicate page, but can be edited like regular promotions after create
- Adds get route for duplicate promo
- Adds link in admin_promotions_path to duplicate page
- Adds duplicate page and styles
- Remove unused conditionals promotion action partials
