### PR TITLE
Fix promotion rule spec to use association

### DIFF
--- a/core/spec/models/spree/promotion_rule_spec.rb
+++ b/core/spec/models/spree/promotion_rule_spec.rb
@@ -26,7 +26,7 @@ module Spree
     end
 
     describe "#duplicate" do
-      let(:promotion) { Spree::Promotion.last || create(:promotion) }
+      let(:promotion) { create(:promotion) }
 
       context "subclass does not define a join_table" do
         it "duplicates itself" do
@@ -39,26 +39,15 @@ module Spree
       end
 
       context "subclass defines a join_table" do
-
-        class TestRule::Product < Spree::PromotionRule
-          attr_accessor :test_rule_test_products
-          self.association_for_duplication = "test_rule_test_products"
-        end
-
-        class TestProduct
-          attr_accessor :promotion_rule_id
-
-          def initialize(id)
-            @promotion_rule_id = id
-          end
-        end
-
         it "duplicates itself with the joined record" do
-          rule = TestRule::Product.new(promotion_id: promotion.id, test_rule_test_products: [TestProduct.new(1)])
+          product = create(:product)
+          rule = Spree::Promotion::Rules::Product.new(promotion_id: promotion.id, products: [product])
           new_rule = rule.duplicate
 
           expect(new_rule).to_not eq rule
-          expect(new_rule.test_rule_test_products.length).to eq rule.test_rule_test_products.length
+          expect(new_rule.products.length).to eq rule.products.length
+          expect(new_rule.products.length).to eq 1
+          expect(new_rule.products.first).to eq product
           expect(new_rule).to be_valid
         end
       end


### PR DESCRIPTION
- #dup will do a shallow copy of the object. That means that it will
  copy the attributes but not the associations. The way that the code is
  written works because we are building new associations. The way that
  the spec was written will not work because the
  #test_rule_test_products was an attribute on the object and therefore
  copied over to the duplicated object. This would cause the
  'association' we were trying to mimick in the spec to be the both
  in the original and dup, therefore adding the association to the
  same array and causing an infinite loop where we map over the original associations.
