### PR TITLE
Add an optional CVV result to spree credit cards.

### DIFF
--- a/core/db/migrate/20160217191300_add_cvv_result_to_spree_credit_cards.rb
+++ b/core/db/migrate/20160217191300_add_cvv_result_to_spree_credit_cards.rb
@@ -1,0 +1,5 @@
+class AddCvvResultToSpreeCreditCards < ActiveRecord::Migration
+  def change
+    add_column :spree_credit_cards, :cvv_result, :string
+  end
+end


### PR DESCRIPTION
A source may be tokenized, when it is, it may have a CVV result as a result of the tokenization. When using braintree, or other providers this can be used in lieu of asking the user for their CVV again.
