### PR TITLE
Change field used for asserting the product has been loaded

### DIFF
--- a/backend/spec/features/admin/products/products_spec.rb
+++ b/backend/spec/features/admin/products/products_spec.rb
@@ -349,7 +349,7 @@ describe "Products", :type => :feature do
         check "Show Deleted"
         click_icon :search
         click_link product.name
-        expect(page).to have_field('Master Price', with: product.price.to_f)
+        expect(page).to have_field('SKU', with: product.sku)
       end
     end
   end


### PR DESCRIPTION
The price logic for deleted products has changed and has already been tested here: https://github.com/bonobos/solidus/commit/1986edc1bfdbaa50b127cbe9dfe700eae584e858.
